### PR TITLE
Add email and username indexes to user table

### DIFF
--- a/db/migrate/20190310225926_add_email_and_username_index_to_users.rb
+++ b/db/migrate/20190310225926_add_email_and_username_index_to_users.rb
@@ -1,0 +1,6 @@
+class AddEmailAndUsernameIndexToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_index :users, :email
+    add_index :users, :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190310223424) do
+ActiveRecord::Schema.define(version: 20190310225926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define(version: 20190310223424) do
     t.datetime "account_activated_at"
     t.string "password_reset_digest"
     t.datetime "password_reset_sent_at"
+    t.index ["email"], name: "index_users_on_email"
+    t.index ["username"], name: "index_users_on_username"
   end
 
   create_table "votes", force: :cascade do |t|


### PR DESCRIPTION
This PR adds email and username indexes to the user table, to ensure searching for users by those fields is speedy.