### PR TITLE
skip active member requirement

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,5 +1,6 @@
 class AccountActivationsController < ApplicationController
   skip_before_action :authorize_api_request, only: :edit
+  skip_before_action :require_active_member, only: :edit
 
   def edit
     user = User.find_by(email: params[:email])


### PR DESCRIPTION
this PR removes the active member requirement from the account_activation route